### PR TITLE
Filter sources type and sort by resolution

### DIFF
--- a/src/js/components/QualitySelector.js
+++ b/src/js/components/QualitySelector.js
@@ -54,18 +54,35 @@ module.exports = function(videojs) {
          this.update();
       },
 
+      orderSources: function(a, b) {
+         if (a.res && b.res) {
+            return parseFloat(a.res) - parseFloat(b.res);
+         }
+         return;
+      },
+
       /**
        * @inheritdoc
        */
       createItems: function() {
          var player = this.player(),
-             sources = player.currentSources();
+             sources = player.currentSources(),
+             singleTypeSources,
+             orderedSources;
 
-         if (!sources || sources.length < 2) {
+         /* filter sources by the current type on the player */
+         singleTypeSources = sources.filter(function(item) {
+            return item.type === player.currentType();
+         });
+
+         /* sort sources by res attributed if exist */
+         orderedSources = singleTypeSources.sort(this.orderSources);
+
+         if (!orderedSources || orderedSources.length < 2) {
             return [];
          }
 
-         return _.map(sources, function(source) {
+         return _.map(orderedSources, function(source) {
             return new QualityOption(player, {
                source: source,
                selected: source.src === this.selectedSrc,


### PR DESCRIPTION
This small addition allows you to use this plugin with multiple types of videos ( for example mp4 and webm ) and also order the labels by passing additional argument of "res" for resolution (that is optional ). 
**Filtering by type:** 
Functionality checks the current type on the player and then filters the sources by the type so you not ending up with duplicated labels for each source type. 

**Sorting by resolution:** 
The part for sorting labels checks if the argument of "res" exist and if it is it orders the labels by values of that attribute for example [{ lebel: High, res: 1400 }, { lebel: Low, res: 360 }, { lebel: Medium, res: 750 } ], so menu alway be Low, Medium, High. If there is no "res" it diplays the order as it comes. 

All those changes are very helpful for the plugin to be used with multiple types and in conjunction with plugins like Language Switch where you replace sources depending on language selection and then quality labels order is all random.