### PR TITLE
Use 'selected = false', over '_.omit' to deselect a source

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -19,7 +19,11 @@ module.exports = function(videojs) {
              isPaused = player.paused(),
              selectedSource;
 
-         sources = _.map(sources, _.partial(_.omit, _, 'selected'));
+         // Clear out any previously selected sources (see: #11)
+         _.each(sources, function(source) {
+            source.selected = false;
+         });
+
          selectedSource = _.findWhere(sources, { src: newSource.src });
          // Note: `_.findWhere` returns a reference to an object. Thus the
          // following updates the original object in `sources`.


### PR DESCRIPTION
From a basic functionality standpoint, this accomplishes the same purpose as
the previous implementation using `_.omit`. However, rather than removing the
`selected` attribute from the sources, this will keep the structure the same by
only altering the value of the source.

If your usage of this plugin requires a stable source format, e.g. for
comparing sources to see if the source changed, please provide the `selected`
attribute when programmatically setting the player source. At this time, we
don't have a simple way to standardize the `selected` attribute on initial
source load. (i.e. It's up to the programmer to set the initial format on the
sources before giving them to the player)