### PR TITLE
fix: Regression bug with the initial source selection

### DIFF
--- a/src/js/components/QualitySelector.js
+++ b/src/js/components/QualitySelector.js
@@ -60,9 +60,7 @@ module.exports = function(videojs) {
          if (this.selectedSrc !== src) {
             this.selectedSrc = src;
             _.each(this.items, function(item) {
-               if (item.source.src !== src) {
-                  item.selected(item.source.src === src);
-               }
+               item.selected(item.source.src === src);
             });
          }
       },


### PR DESCRIPTION
The if (item.source.src !== src) had to be removed for the initial selection to be applied