### PR TITLE
docs: Remove data-setup property to prevent double initialization (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ instance of a `video.js` player.
 #### Using `<source>`
 
 ```html
-<video id="video_1" class="video-js vjs-default-skin" controls preload="auto" width="640" height="268" data-setup='{}'>
+<video id="video_1" class="video-js vjs-default-skin" controls preload="auto" width="640" height="268">
    <source src="https://example.com/video_720.mp4" type="video/mp4" label="720P">
    <source src="https://example.com/video_480.mp4" type="video/mp4" label="480P" selected="true">
    <source src="https://example.com/video_360.mp4" type="video/mp4" label="360P">
@@ -114,7 +114,11 @@ There are at least two ways to add the quality selector control to the player's 
 bar. The first is directly adding it via `addChild`. For example:
 
 ```js
-player.controlBar.addChild('QualitySelector');
+videojs('video_1', {}, function() {
+   var player = this;
+
+   player.controlBar.addChild('QualitySelector');
+});
 ```
 
 The second option is to add the control via the player's options, for instance:

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -11,7 +11,7 @@
 <body>
    <h1>Demo of <code>videojs-quality-selector</code></h1>
 
-   <video id="video_1" class="video-js vjs-default-skin" controls preload="auto" data-setup='{}'>
+   <video id="video_1" class="video-js vjs-default-skin" controls preload="auto">
       <source src="https://upload.wikimedia.org/wikipedia/commons/transcoded/a/ab/Caminandes_3_-_Llamigos_-_Blender_Animated_Short.webm/Caminandes_3_-_Llamigos_-_Blender_Animated_Short.webm.720p.webm" type="video/webm" label="720P">
       <source src="https://upload.wikimedia.org/wikipedia/commons/transcoded/a/ab/Caminandes_3_-_Llamigos_-_Blender_Animated_Short.webm/Caminandes_3_-_Llamigos_-_Blender_Animated_Short.webm.480p.webm" type="video/webm" label="480P" selected="true">
       <source src="https://upload.wikimedia.org/wikipedia/commons/transcoded/a/ab/Caminandes_3_-_Llamigos_-_Blender_Animated_Short.webm/Caminandes_3_-_Llamigos_-_Blender_Animated_Short.webm.360p.webm" type="video/webm" label="360P">
@@ -19,7 +19,7 @@
    </video>
 
    <script>
-      videojs("video_1", {}, function() {
+      videojs('video_1', {}, function() {
          var player = this;
 
          player.controlBar.addChild('QualitySelector');


### PR DESCRIPTION
Using the `data-setup` attribute in the video component will automatically initialize the player with the options provided. However, if the player is also initialized in our code using the `videojs('my-player')` function, this can sometimes cause the issue described in #70, where the quality selector is unable to change sources. 

These changes remove the `data-setup` attribute from the documentation and demo to prevent this from occuring.